### PR TITLE
Fix metadata related to supported platforms.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,10 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
-    - name: Darwin
+    - name: Alpine
+      versions:
+        - all
+    - name: MacOSX
       versions:
         - all
 


### PR DESCRIPTION
FYI: https://galaxy.ansible.com/api/v1/platforms/

- Now, Alpine is supported in Galaxy.
- Now, MacOS is used instead of Darwin.